### PR TITLE
minor tweak to regex'es

### DIFF
--- a/lib/autoclose-html.coffee
+++ b/lib/autoclose-html.coffee
@@ -1,7 +1,7 @@
 concatPattern = /\s*[,|]+\s*/g
-isTagLikePattern = /<(?![\!\/])([a-z]{1}[^>\s=\'\"]*)/i
-isOpeningTagLikePattern = /<(?![\!\/])([a-z]{1}[^>\s=\'\"]*)/i
-isClosingTagLikePattern = /<\/([a-z]{1}[^>\s=\'\"]*)/i
+#isTagLikePattern = /<(?![\!\/])([a-z]{1}[^>\s=\'\"]*)/i
+isOpeningTagLikePattern = /<(?![\!\/])([a-z]{1}[^>\s=\'\"]*)$/i
+#isClosingTagLikePattern = /<\/([a-z]{1}[^>\s=\'\"]*)/i
 
 module.exports =
     configDefaults:


### PR DESCRIPTION
isTagLikePattern and isClosingTagLikePattern are not used? end isOpeningTagLikePattern with '$' to force open tag at end of current input, (just to avoid acting twice on accidental input of "<x>>")