### PR TITLE
add alwaysInline option to always have closing tag inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Will convert elements in Never Close list from `<br>` to `<br />`
 ~~Under normal circumstances this package will only run in editors with HTML set as the grammar. If you would like to force it to run else where, check this.  Please note templating languages which use `<` and `>` for things other than HTML will likely trigger false-positives/be annoying.~~
 This option was removed in 0.9.0, if you had it checked prior to that Additional Grammars will be set to "*" on load
 
+## Always Inline
+
+If this option is selected, all closing tags will be rendered on the same line.
 
 # TODO
 * Add option to autocomplete after `</` of closing tag. (requires parsing of whole document to figure out what the open element is)

--- a/lib/autoclose-html.coffee
+++ b/lib/autoclose-html.coffee
@@ -12,6 +12,7 @@ module.exports =
     grammars: defaultGrammars
     makeNeverCloseSelfClosing: false
     ignoreGrammar: false
+    alwaysInLine: false
 
     activate: () ->
 
@@ -33,6 +34,9 @@ module.exports =
         atom.config.observe 'autoclose-html.makeNeverCloseSelfClosing', (value) =>
             @makeNeverCloseSelfClosing = value
 
+        atom.config.observe 'autoclose-html.alwaysInLine', (value) =>
+            @alwaysInLine = value
+
         @_events()
 
     isInline: (eleTag) ->
@@ -41,7 +45,9 @@ module.exports =
         catch
             return false
 
-        if eleTag.toLowerCase() in @forceBlock
+        if @alwaysInLine
+            return true
+        else if eleTag.toLowerCase() in @forceBlock
             return false
         else if eleTag.toLowerCase() in @forceInline
             return true

--- a/lib/configuration.coffee
+++ b/lib/configuration.coffee
@@ -26,3 +26,8 @@ module.exports =
             description: 'Closes elements with " />" (ie <br> becomes <br />)'
             type: 'boolean'
             default: true
+        alwaysInLine:
+          title: 'Always Inline'
+          description: 'Overrides forceInline. If this is selected, ALL elements will have their closing tags on the same line'
+          type: 'boolean'
+          default: false


### PR DESCRIPTION
For a while I was switching to sublime when working with html because I couldn't find an html autocompletion package I liked, but I really like this one. My one suggestion would be to add an option to always add the closing tag inline. I decided to throw something together myself to see what you guys thought of it. This functionality isn't completely necessary, and really I could just adapt to use the current implementation, but I thought it's a nice-to-have feature and after using this change myself I thought I'd submit a PR for it.

Thanks for the awesome package!