### PR TITLE
fixed duplicate closing tags after grammar change

### DIFF
--- a/lib/autoclose-html.coffee
+++ b/lib/autoclose-html.coffee
@@ -117,6 +117,7 @@ module.exports =
             @autocloseHTMLEvents = new CompositeDisposable
         atom.workspace.observeTextEditors (textEditor) =>
             textEditor.observeGrammar (grammar) =>
-                textEditor.autocloseHTMLbufferEvent.dispose() if bufferEvent?
+                textEditor.autocloseHTMLbufferEvent.dispose() if textEditor.autocloseHTMLbufferEvent?
                 if grammar.name?.length > 0 and (@ignoreGrammar or grammar.name in @grammars)
-                     @autocloseHTMLEvents.add(textEditor.buffer.onDidChange (e) => @execAutoclose e, textEditor)
+                     textEditor.autocloseHTMLbufferEvent = textEditor.buffer.onDidChange (e) => @execAutoclose e, textEditor
+                     @autocloseHTMLEvents.add(textEditor.autocloseHTMLbufferEvent)


### PR DESCRIPTION
It looks like this is what is supposed to be happening? I'm not super familiar with Atom's api, so if I'm doing something silly here by storing this on the textEditor just let me know.