### PR TITLE
Remove forward slash from eleTag

### DIFF
--- a/lib/autoclose-html.coffee
+++ b/lib/autoclose-html.coffee
@@ -72,6 +72,7 @@ module.exports =
         ret
 
     isNeverClosed: (eleTag) ->
+        eleTag = eleTag.replace('/', '')
         eleTag.toLowerCase() in @neverClose
 
     execAutoclose: () ->


### PR DESCRIPTION
This PR should fix #152. When searching for the element in @neverClose, it was including the forward slash. There may be other fixes to this problem, but this was the easiest one I saw.

I guess there could be another fix by examining isOpeningTagLikePattern and see why it's including the slash in it matches.