### PR TITLE
Restore JSX support

### DIFF
--- a/keymaps/autoclose-html.cson
+++ b/keymaps/autoclose-html.cson
@@ -9,5 +9,5 @@
 # https://atom.io/docs/latest/advanced/keymaps
 #'.workspace':
 
-'atom-text-editor[data-grammar~="html"]':
+'atom-text-editor[data-grammar~="html"], atom-text-editor[data-grammar~="jsx"]':
 	'>': 'autoclose-html:close-and-complete'


### PR DESCRIPTION
@mattberkowitz It looks like JSX support was unintentionally removed by https://github.com/mattberkowitz/autoclose-html/commit/73cdb1292978c3b491ef5adc24bb108001aebce3, since JSX grammars do not match that `data-grammar` selector:

<img width="835" alt="screen shot 2016-08-06 at 7 23 59 pm" src="https://cloud.githubusercontent.com/assets/224895/17459570/d5aca7ea-5c0b-11e6-8298-f95988c1cfa6.png">

This PR enables autoclose-html whenever the grammar contains either `html` or `jsx`.
