### PR TITLE
Fix self-close at end-of-line

### DIFF
--- a/lib/autoclose-html.coffee
+++ b/lib/autoclose-html.coffee
@@ -83,7 +83,7 @@ module.exports =
         partial = line.substr 0, range.start.column
         partial = partial.substr(partial.lastIndexOf('<'))
 
-        return if partial.substr(partial.length - 1, 1) is '/'
+        return if partial.substr(partial.length - 2, 2) is '/>'
 
         singleQuotes = partial.match(/\'/g)
         doubleQuotes = partial.match(/\"/g)

--- a/lib/autoclose-html.coffee
+++ b/lib/autoclose-html.coffee
@@ -106,7 +106,7 @@ module.exports =
         if @isNeverClosed(eleTag)
             if @makeNeverCloseSelfClosing
                 tag = '/>'
-                if partial.substr partial.length - 1, 1 isnt ' '
+                if partial.substr(partial.length - 2, 2) isnt ' >'
                     tag = ' ' + tag
                 editor.backspace()
                 editor.insertText tag


### PR DESCRIPTION
When `makeNeverCloseSelfClosing` is `true`:

* Typing <kbd>/&gt;</kbd> at EOL now correctly inserts <kbd>&nbsp;/&gt;</kbd> rather than <kbd>/&nbsp;/&gt;</kbd>.
* Typing <kbd>&nbsp;&gt;</kbd> at EOL now correctly inserts <kbd>&nbsp;/&gt;</kbd> rather than <kbd>&nbsp;&nbsp;/&gt;</kbd>.

In both cases, the end-of-`partial` check wasn't accounting for the fact that the `>` has already been added to the line.

### Before
![autoclose-selfclose-broken](https://user-images.githubusercontent.com/133987/27190429-07411fda-51ba-11e7-992e-27adf91daa95.gif)

### After
![autoclose-selfclose-fixed](https://user-images.githubusercontent.com/133987/27190845-67304e74-51bb-11e7-8ab1-95d2dac3243c.gif)
