### PR TITLE
fix #177

### DIFF
--- a/lib/autoclose-html.coffee
+++ b/lib/autoclose-html.coffee
@@ -83,7 +83,7 @@ module.exports =
         partial = line.substr 0, range.start.column
         partial = partial.substr(partial.lastIndexOf('<'))
 
-        return if partial.substr(partial.length - 1, 1) is '/'
+        return if partial.substr(partial.length - 2, 1) is '/'
 
         singleQuotes = partial.match(/\'/g)
         doubleQuotes = partial.match(/\"/g)


### PR DESCRIPTION
Maybe old versions of atom give you the string not include the `>` when you hit `>`.


But I tested it on my atom ver 1.18.0, when hit `>`, the string returned from the event do includes the `>`. 

So it seems that we should check the character '/' at position `partial.length - 2`