### PR TITLE
Align closing tag

### DIFF
--- a/lib/autoclose-html.coffee
+++ b/lib/autoclose-html.coffee
@@ -122,7 +122,7 @@ module.exports =
             editor.insertNewline()
             editor.insertNewline()
             if @alignClosingTag
-              editor.backspace()
+                editor.backspace()
         editor.insertText('</' + eleTag + '>')
         if isInline
             editor.setCursorBufferPosition range.end

--- a/lib/autoclose-html.coffee
+++ b/lib/autoclose-html.coffee
@@ -12,6 +12,7 @@ module.exports =
     makeNeverCloseSelfClosing: false
     ignoreGrammar: false
     legacyMode: false
+    alignClosingTag: false
 
     activate: () ->
 
@@ -45,6 +46,9 @@ module.exports =
                 @_events()
             else
                 @_unbindEvents()
+
+        atom.config.observe 'autoclose-html.alignClosingTag', (value) =>
+            @alignClosingTag = value
 
 
     deactivate: ->
@@ -117,6 +121,8 @@ module.exports =
         if not isInline
             editor.insertNewline()
             editor.insertNewline()
+        if @alignClosingTag
+          editor.backspace()
         editor.insertText('</' + eleTag + '>')
         if isInline
             editor.setCursorBufferPosition range.end

--- a/lib/autoclose-html.coffee
+++ b/lib/autoclose-html.coffee
@@ -121,8 +121,8 @@ module.exports =
         if not isInline
             editor.insertNewline()
             editor.insertNewline()
-        if @alignClosingTag
-          editor.backspace()
+            if @alignClosingTag
+              editor.backspace()
         editor.insertText('</' + eleTag + '>')
         if isInline
             editor.setCursorBufferPosition range.end

--- a/lib/configuration.coffee
+++ b/lib/configuration.coffee
@@ -25,3 +25,8 @@ module.exports =
             description: "Do not use this unless you use a non-US or non-QUERTY keyboard and/or the plugin isn't working otherwise. USING THIS OPTION WILL OPT YOU OUT OF NEW IMPROVEMENTS/FEATURES POST 0.22.0"
             type: 'boolean'
             default: false
+        alignClosingTag:
+            title: "Align the Closing Tag to the Same Column"
+            description: "When an element is autoclosed, the closing tag will align to the same column as the opening tag."
+            type: 'boolean'
+            default: false


### PR DESCRIPTION
Implemented a new option in the package setting to align the closing tag starting column to the same starting column as the opening tag. This only takes affect if the setting is selected (default it is not) and the element is not an inline element. 