### PR TITLE
Correct extra indentation on block close tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Install using
 
 `apm install autoclose-html`
 
-Until merge of this fork, install as follows:
+Until merge of this fork, install using temporary installation process as follows:
 
 1. Uninstall autoclose-html 0.24.0
 2. open a terminal and ...
@@ -84,3 +84,6 @@ be removed.
 
 #### 0.24.0
 - Stopped self closing tags from auto closing
+
+#### 0.24.1
+- Fixes extra indentation on block close tags. Presumes the use of autoindent. 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,25 @@
 # Auto Close HTML package for Atom Text Editor
 
 Will automatically add closing tags when you complete the opening tag.
+Updated to correct extra indentation of closing tags on block elements.
 
 # Installation
 
 Install using
 
 `apm install autoclose-html`
+
+Until merge of this fork, install as follows:
+
+1. Uninstall autoclose-html 0.24.0
+2. open a terminal and ...
+3. > cd ~/.atom/packages
+4. > git clone https://github.com/Ordinal-Data-Inc/autoclose-html.git
+5. > cd autoclose-html
+6. > npm install
+7. > restart Atom
+8. Check that Atom > preferences > packages shows autoclose-html 0.24.1
+9. (Optional) Have a sip of coffee   
 
 # Usage
 

--- a/lib/autoclose-html.coffee
+++ b/lib/autoclose-html.coffee
@@ -116,7 +116,7 @@ module.exports =
 
         if not isInline
             editor.insertNewline()
-            editor.backspace()
+            editor.backspace() # corrects extra indentation on block close
             editor.insertNewline()
         editor.insertText('</' + eleTag + '>')
         if isInline

--- a/lib/autoclose-html.coffee
+++ b/lib/autoclose-html.coffee
@@ -116,6 +116,7 @@ module.exports =
 
         if not isInline
             editor.insertNewline()
+            editor.backspace()
             editor.insertNewline()
         editor.insertText('</' + eleTag + '>')
         if isInline

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "Matt Berkowitz"
   },
   "main": "./lib/autoclose-html",
-  "version": "0.24.1",
+  "version": "0.24.1", 
   "private": true,
   "description": "Automates closing of HTML Tags",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "Matt Berkowitz"
   },
   "main": "./lib/autoclose-html",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "private": true,
   "description": "Automates closing of HTML Tags",
   "repository": {


### PR DESCRIPTION
Issue 217 identifies an extra ident on the close tag for block tags.  The code fix adds a backspace and corrects the problem which occurs when using autoindent.  I have not tested when not using autoindent.  I will work on that next. 